### PR TITLE
Fix power_enum to work with Rails 4.2

### DIFF
--- a/lib/power_enum/reflection.rb
+++ b/lib/power_enum/reflection.rb
@@ -48,7 +48,17 @@ module PowerEnum::Reflection
 
     # See ActiveRecore::Reflection::MacroReflection
     def initialize( name, options, active_record )
-      super name, nil, options, active_record
+      if Rails.version =~ /^4\.2.*/
+        super name, nil, options, active_record
+      else
+        super :has_enumerated, nil, options, active_record
+      end
+    end
+
+    if Rails.version =~ /^4\.2.*/
+      def macro
+        :has_enumerated
+      end
     end
 
     # Returns the class name of the enum


### PR DESCRIPTION
Looks like Rails 4.2.0 removed the first `macro` argument to
`ActiveRecord::Reflection::MacroReflection#initialize` - see
rails/rails@f8d2899
