### PR TITLE
4109 Make compatible with ActiveRecord 4.1.10

### DIFF
--- a/lib/power_enum/reflection.rb
+++ b/lib/power_enum/reflection.rb
@@ -112,7 +112,7 @@ of these associations is deprecated and will be removed in the future.
 
     # Returns the primary key of the active record model that owns the has_enumerated
     # association.
-    def association_primary_key
+    def association_primary_key(klass = nil)
       active_record.primary_key
     end
 


### PR DESCRIPTION
Task 4109

add: default klass argument to PowerEnum::Reflection::EnumerationReflection#association_primary_key

Tests pass.