### PR TITLE
Remove Deprecated Code

### DIFF
--- a/lib/testing/rspec.rb
+++ b/lib/testing/rspec.rb
@@ -87,7 +87,7 @@ if defined? RSpec
       end
     end
 
-    failure_message_for_should do
+    failure_message do
       message = "should act as enumerated"
       if @items
         message << " and have members #{@items.inspect}"
@@ -95,7 +95,7 @@ if defined? RSpec
       message
     end
 
-    failure_message_for_should_not do
+    failure_message_when_negated do
       message = "should not act as enumerated"
       if @items
         message << " with members #{@items.inspect}"
@@ -131,11 +131,11 @@ if defined? RSpec
       model_class.has_enumerated?(attribute)
     end
 
-    failure_message_for_should do
+    failure_message do
       "expected #{attribute} to be an enumerated attribute"
     end
 
-    failure_message_for_should_not do
+    failure_message_when_negated do
       "expected #{attribute} to not be an enumerated attribute"
     end
 
@@ -166,11 +166,11 @@ if defined? RSpec
       end
     end
 
-    failure_message_for_should do
+    failure_message do
       "expected #{attribute} to match the enum"
     end
 
-    failure_message_for_should_not do
+    failure_message_when_negated do
       "expected #{attribute} to not match the enum"
     end
 


### PR DESCRIPTION
When running code in a test suite, it would throw the following warning
messages:

    Deprecation Warnings:

    `failure_message_for_should_not` is deprecated. Use
    `failure_message_when_negated` instead. Called from
    lib/testing/rspec.rb:98:in `block in <top (required)>'.

    `failure_message_for_should` is deprecated. Use
    `failure_message` instead. Called from
    lib/testing/rspec.rb:90:in `block in <top (required)>'.

    If you need more of the backtrace for any of these deprecations to
    identify where to make the necessary changes, you can configure
    `config.raise_errors_for_deprecations!`, and it will turn the
    deprecation warnings into errors, giving you the full backtrace.

    2 deprecation warnings total

This change adopts the newer, generic DSL for writing RSpec matchers.

When testing these changes, they came back all green, but the file `spec/dummy/db/schema.rb` had been changed. Reviewing those changes, it showed that all the `force: true` settings in the table declarations had been changed to `force: :cascade`. I did not include that file in this PR as I'm unsure if the source of it was a specific thing in Rails or my setup. I'm more happy to include that diff if desired.