### PR TITLE
Ruby 2.4 compatibility

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -307,13 +307,13 @@ With that, your BookingStatus class will have the following methods defined:
 
 `BookingStatus[arg]` performs a lookup for the BookingStatus instance for the given arg. The arg value can be a
 'string' or a :symbol, in which case the lookup will be against the BookingStatus.name field. Alternatively arg can be
-a Fixnum, in which case the lookup will be against the BookingStatus.id field. It returns the arg if arg is an
+a Integer, in which case the lookup will be against the BookingStatus.id field. It returns the arg if arg is an
 instance of the enum (in this case BookingStatus) as a convenience.
 
 The `:on_lookup_failure` option specifies the name of a *class* method to invoke when the `[]` method is unable to
 locate a BookingStatus record for arg. The default is the built-in `:enforce_none` which returns nil. There are also
 built-ins for `:enforce_strict` (raise and exception regardless of the type for arg), `:enforce_strict_literals` (raises
-an exception if the arg is a Fixnum or Symbol), `:enforce_strict_ids` (raises and exception if the arg is a Fixnum) and
+an exception if the arg is a Integer or Symbol), `:enforce_strict_ids` (raises and exception if the arg is a Integer) and
 `:enforce_strict_symbols` (raises an exception if the arg is a Symbol).
 
 The purpose of the `:on_lookup_failure` option is that a) under some circumstances a lookup failure is a Bad Thing and
@@ -388,7 +388,7 @@ Each enumeration model gets the following instance methods.
 Behavior depends on the type of `arg`.
 
 * If `arg` is `nil`, returns `false`.
-* If `arg` is an instance of `Symbol`, `Fixnum` or `String`, returns the result of `BookingStatus[:foo] == BookingStatus[arg]`.
+* If `arg` is an instance of `Symbol`, `Integer` or `String`, returns the result of `BookingStatus[:foo] == BookingStatus[arg]`.
 * If `arg` is an `Array`, returns `true` if any member of the array returns `true` for `===(arg)`, `false` otherwise.
 * In all other cases, delegates to `===(arg)` of the superclass.
 

--- a/lib/generators/enum/enum_generator_helpers/migration_number.rb
+++ b/lib/generators/enum/enum_generator_helpers/migration_number.rb
@@ -4,7 +4,7 @@ module EnumGeneratorHelpers
   module MigrationNumber
     # Returns the next upcoming migration number.  Sadly, Rails has no API for
     # this, so we're reduced to copying from ActiveRecord::Generators::Migration
-    # @return [Fixnum]
+    # @return [Integer]
     def next_migration_number(dirname)
       # Lifted directly from ActiveRecord::Generators::Migration
       # Unfortunately, no API is provided by Rails at this time.

--- a/lib/power_enum/enumerated.rb
+++ b/lib/power_enum/enumerated.rb
@@ -25,8 +25,8 @@ module PowerEnum::Enumerated
     #   Specifies the name of a class method to invoke when the +[]+ method is unable to locate a BookingStatus
     #   record for arg. The default is the built-in :enforce_none which returns nil. There are also built-ins for
     #   :enforce_strict (raise and exception regardless of the type for arg), :enforce_strict_literals (raises an
-    #   exception if the arg is a Fixnum or Symbol), :enforce_strict_ids (raises and exception if the arg is a
-    #   Fixnum) and :enforce_strict_symbols (raises an exception if the arg is a Symbol).  The purpose of the
+    #   exception if the arg is a Integer or Symbol), :enforce_strict_ids (raises and exception if the arg is a
+    #   Integer) and :enforce_strict_symbols (raises an exception if the arg is a Symbol).  The purpose of the
     #   :on_lookup_failure option is that a) under some circumstances a lookup failure is a Bad Thing and action
     #   should be taken, therefore b) a fallback action should be easily configurable.  You can also give it a
     #   lambda that takes in a single argument (The arg that was passed to +[]+).
@@ -218,7 +218,7 @@ module PowerEnum::Enumerated
         !!lookup_name(arg.id2name)
       when String
         !!lookup_name(arg)
-      when Fixnum
+      when Integer
         !!lookup_id(arg)
       when self
         true
@@ -244,7 +244,7 @@ module PowerEnum::Enumerated
         !lookup_name(arg.id2name).nil?
       when String
         !lookup_name(arg).nil?
-      when Fixnum
+      when Integer
         !lookup_id(arg).nil?
       when self
         possible_match = lookup_id(arg.id)
@@ -322,7 +322,7 @@ module PowerEnum::Enumerated
         lookup_name(arg.id2name)
       when String
         lookup_name(arg)
-      when Fixnum
+      when Integer
         lookup_id(arg)
       when self
         arg
@@ -330,7 +330,7 @@ module PowerEnum::Enumerated
         nil
       else
         raise TypeError, "#{self.name}[]: argument should"\
-                         " be a String, Symbol or Fixnum but got a: #{arg.class.name}"
+                         " be a String, Symbol or Integer but got a: #{arg.class.name}"
       end
     end
     private :lookup_enum_by_type
@@ -390,13 +390,13 @@ module PowerEnum::Enumerated
     private :enforce_strict
 
     def enforce_strict_literals(arg) # :nodoc:
-      raise_record_not_found(arg) if (Fixnum === arg) || (Symbol === arg)
+      raise_record_not_found(arg) if (Integer === arg) || (Symbol === arg)
       nil
     end
     private :enforce_strict_literals
 
     def enforce_strict_ids(arg) # :nodoc:
-      raise_record_not_found(arg) if Fixnum === arg
+      raise_record_not_found(arg) if Integer === arg
       nil
     end
     private :enforce_strict_ids
@@ -421,7 +421,7 @@ module PowerEnum::Enumerated
     # Behavior depends on the type of +arg+.
     #
     # * If +arg+ is +nil+, returns +false+.
-    # * If +arg+ is an instance of +Symbol+, +Fixnum+ or +String+, returns the result of +BookingStatus[:foo] == BookingStatus[arg]+.
+    # * If +arg+ is an instance of +Symbol+, +Integer+ or +String+, returns the result of +BookingStatus[:foo] == BookingStatus[arg]+.
     # * If +arg+ is an +Array+, returns +true+ if any member of the array returns +true+ for +===(arg)+, +false+ otherwise.
     # * In all other cases, delegates to +===(arg)+ of the superclass.
     #
@@ -439,7 +439,7 @@ module PowerEnum::Enumerated
       case arg
       when nil
         false
-      when Symbol, String, Fixnum
+      when Symbol, String, Integer
         return self == self.class[arg]
       when Array
         return self.in?(*arg)

--- a/lib/power_enum/has_enumerated.rb
+++ b/lib/power_enum/has_enumerated.rb
@@ -172,14 +172,14 @@ module PowerEnum::HasEnumerated
             val = #{class_name}.lookup_name(arg)
           when Symbol
             val = #{class_name}.lookup_name(arg.id2name)
-          when Fixnum
+          when Integer
             val = #{class_name}.lookup_id(arg)
           when nil
             self.#{foreign_key} = nil
             @invalid_enum_values.delete :#{attribute_name}
             return nil
           else
-            raise TypeError, "#{self.name}: #{attribute_name}= argument must be a #{class_name}, String, Symbol or Fixnum but got a: \#{arg.class.attribute_name}"
+            raise TypeError, "#{self.name}: #{attribute_name}= argument must be a #{class_name}, String, Symbol or Integer but got a: \#{arg.class.attribute_name}"
           end
 
           if val.nil?

--- a/lib/testing/rspec.rb
+++ b/lib/testing/rspec.rb
@@ -71,7 +71,7 @@ if defined? RSpec
     # Validates the given enum.
     def validate_enum(enum_class, item)
       case item
-      when String, Symbol, Fixnum
+      when String, Symbol, Integer
         enum_class[item].present?
       when Hash
         name = item[:name]

--- a/spec/dummy/db/schema.rb
+++ b/spec/dummy/db/schema.rb
@@ -40,8 +40,8 @@ ActiveRecord::Schema.define(version: 20120909235526) do
     t.string   "name",        limit: 50,                null: false
     t.string   "description"
     t.boolean  "active",                 default: true, null: false
-    t.datetime "created_at"
-    t.datetime "updated_at"
+    t.datetime "created_at",                            null: false
+    t.datetime "updated_at",                            null: false
     t.boolean  "has_sound",                             null: false
     t.index ["name"], name: "index_connector_types_on_name", unique: true
   end

--- a/spec/functional/acts_as_enumerated_spec.rb
+++ b/spec/functional/acts_as_enumerated_spec.rb
@@ -96,7 +96,7 @@ describe 'acts_as_enumerated' do
           status.name_sym.should == :confirmed
         end
 
-        it 'returns a record found by id when Fixnum is passed' do
+        it 'returns a record found by id when Integer is passed' do
           status = BookingStatus[1]
           status.should be_an_instance_of BookingStatus
           status.__enum_name__.should == 'confirmed'
@@ -120,7 +120,7 @@ describe 'acts_as_enumerated' do
           state.name_sym.should == :IL
         end
 
-        it 'returns a record found by id when Fixnum is passed' do
+        it 'returns a record found by id when Integer is passed' do
           state = State[1]
           state.should be_an_instance_of State
           state.state_code.should == 'IL'
@@ -169,7 +169,7 @@ describe 'acts_as_enumerated' do
           expect { State[:XXX] }.to raise_error ActiveRecord::RecordNotFound
         end
 
-        it 'raises if Fixnum is passed' do
+        it 'raises if Integer is passed' do
           expect { State[999_999] }.to raise_error ActiveRecord::RecordNotFound
         end
 
@@ -372,7 +372,7 @@ describe 'acts_as_enumerated' do
   end
 
   describe 'in?' do
-    it 'in? should find by Symbol, String, or Fixnum' do
+    it 'in? should find by Symbol, String, or Integer' do
       [1, :IL, 'IL'].each do |arg|
         State[:IL].in?(arg).should eq(true)
       end

--- a/spec/functional/has_enumerated_spec.rb
+++ b/spec/functional/has_enumerated_spec.rb
@@ -123,7 +123,7 @@ describe 'has_enumerated' do
       status.name.should == 'confirmed'
     end
 
-    it 'assigns and returns an appropriate status when Fixnum is passed' do
+    it 'assigns and returns an appropriate status when Integer is passed' do
       @booking.status = 1
       status = @booking.status
       status.should_not be_new_record


### PR DESCRIPTION
## Unify Fixnum and Bignum into Integer
https://bugs.ruby-lang.org/issues/12005

This fixes the Ruby 2.4 warning:
`power_enum-2.9.1/lib/power_enum/has_enumerated.rb:174: warning: constant ::Fixnum is deprecated`
