### PR TITLE
Update power_enum_2 for ghenghis Ruby 3 upgrade

### DIFF
--- a/lib/power_enum/schema/schema_statements.rb
+++ b/lib/power_enum/schema/schema_statements.rb
@@ -92,7 +92,7 @@ module PowerEnum::Schema
       desc_limit = options[:desc_limit]
       table_options = options[:table_options] || {}
 
-      create_table enum_table_name, table_options do |t|
+      create_table enum_table_name, **table_options do |t|
         t.string name_column, :limit => name_limit, :null => false
         if generate_description
           t.string :description, :limit => desc_limit


### PR DESCRIPTION
## Description
This PR is 7 of 7 gem changes for the Upgrade of Ruby happening in [Ghenghis](https://github.com/CityBaseInc/ghenghis). Ruby 2.7.6 is being upgraded to Ruby 3.0.5.

Positional and keyword arguments will now be separated.
[PLFM-109](https://citybase.atlassian.net/browse/PLFM-109)

## Changes

* [x] Changes made to support the way keyword arguments are now handled

## Guidelines
[PR Author and Reviewer guidelines](https://citybase.atlassian.net/wiki/spaces/DEV/pages/549322760/Code+Review+Guidelines)

## QA Steps
(optional)

## Concerns
(optional)

## Justification for no test coverage
(optional)

## Dependencies (other repos or epic branch)
[enQuesta_api](https://github.com/CityBaseInc/enQuesta_api/pull/16)
[forte_api](https://github.com/CityBaseInc/forte_api/pull/8)
[indy_marion_county_treasurer_api](https://github.com/CityBaseInc/indy_marion_county_treasurer_api/pull/4)
[tyler_new_world_api](https://github.com/CityBaseInc/tyler_new_world_api/pull/14)
[enum_state_machine](https://github.com/HornsAndHooves/enum_state_machine/pull/10)
[coc_crs_api](https://github.com/CityBaseInc/coc_crs_api/pull/32)
[power_enum_2](https://github.com/albertosaurus/power_enum_2/pull/27)
## Screenshots
(optional)


[PLFM-109]: https://citybase.atlassian.net/browse/PLFM-109?atlOrigin=eyJpIjoiNWRkNTljNzYxNjVmNDY3MDlhMDU5Y2ZhYzA5YTRkZjUiLCJwIjoiZ2l0aHViLWNvbS1KU1cifQ